### PR TITLE
Some docker_check_tests.sh fixes for 494

### DIFF
--- a/tests/scripts/docker_check_tests.sh
+++ b/tests/scripts/docker_check_tests.sh
@@ -9,6 +9,7 @@ while true; do
         if docker inspect --format='{{.State.Running}}' "$container_name" | grep -q "false"; then
             echo "tests are finished"
             EXIT_CODE=$(docker inspect "$container_name" --format='{{.State.ExitCode}}')
+            docker-compose -f docker-compose-tests.yml logs selenium-tests
             if [ "$EXIT_CODE" -eq 0 ]; then
                 echo "tests finished with code $EXIT_CODE (OK)"
                 exit 0

--- a/tests/scripts/docker_check_tests.sh
+++ b/tests/scripts/docker_check_tests.sh
@@ -6,7 +6,7 @@ container_id=$(docker-compose -f docker-compose-tests.yml ps -q $service)
 
 while true; do
 
-    if docker ps -a -q | grep -q "^${container_id}$"; then
+    if docker ps -a -q --no-trunc| grep -q "^${container_id}$"; then
         if docker inspect --format='{{.State.Running}}' "$container_id" | grep -q "false"; then
             echo "tests are finished"
             EXIT_CODE=$(docker inspect "$container_id" --format='{{.State.ExitCode}}')

--- a/tests/scripts/docker_check_tests.sh
+++ b/tests/scripts/docker_check_tests.sh
@@ -1,14 +1,15 @@
 # !/bin/bash
 
-container_name="mse_auto_checking_slides_vaganov_selenium-tests_1"
+service="selenium-tests"
+container_id=$(docker-compose -f docker-compose-tests.yml ps -q $service)
 
 
 while true; do
 
-    if docker ps -a --format '{{.Names}}' | grep -q "^${container_name}$"; then
-        if docker inspect --format='{{.State.Running}}' "$container_name" | grep -q "false"; then
+    if docker ps -a -q | grep -q "^${container_id}$"; then
+        if docker inspect --format='{{.State.Running}}' "$container_id" | grep -q "false"; then
             echo "tests are finished"
-            EXIT_CODE=$(docker inspect "$container_name" --format='{{.State.ExitCode}}')
+            EXIT_CODE=$(docker inspect "$container_id" --format='{{.State.ExitCode}}')
             docker-compose -f docker-compose-tests.yml logs selenium-tests
             if [ "$EXIT_CODE" -eq 0 ]; then
                 echo "tests finished with code $EXIT_CODE (OK)"
@@ -22,7 +23,7 @@ while true; do
             sleep 30
         fi
     else
-        echo "Контейнер $container_name не найден."
+        echo "Контейнер сервиса $service не найден."
         exit 1
     fi
 


### PR DESCRIPTION
- добавил работу с контейнером по имени сервиса + ID контейнера (поскольку hardcoded-name - не хорошо, плюс мы поменяли название репозитория - поменялся и docker-compose проект, т.к. его имя = имя текущей папки)
- добавил вывод логов ДО exit 1 / 0, потому что при exit 1 - action заканчивается и до следующего шага (где как раз show tests logs) выполнение не доходит